### PR TITLE
Add LeaveDAO leave management and PerformanceDAO interface for performance review operations

### DIFF
--- a/src/main/java/com/revature/revworkforce/dao/PerformanceDAO.java
+++ b/src/main/java/com/revature/revworkforce/dao/PerformanceDAO.java
@@ -1,0 +1,29 @@
+package com.revature.revworkforce.dao;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import com.revature.revworkforce.model.PerformanceReview;
+
+/**
+ * DAO Interface for Performance Review operations
+ */
+public interface PerformanceDAO {
+    
+    // Performance Review Operations
+    int createPerformanceReview(PerformanceReview review) throws SQLException;
+    boolean updatePerformanceReview(PerformanceReview review) throws SQLException;
+    boolean submitPerformanceReview(int reviewId) throws SQLException;
+    boolean addManagerFeedback(int reviewId, String managerId, String feedback, 
+                               double rating) throws SQLException;
+    
+    // Read Operations
+    PerformanceReview getPerformanceReviewById(int reviewId) throws SQLException;
+    List<PerformanceReview> getReviewsByEmployee(String employeeId) throws SQLException;
+    PerformanceReview getReviewByEmployeeAndYear(String employeeId, int year) throws SQLException;
+    List<PerformanceReview> getPendingReviewsByManager(String managerId) throws SQLException;
+    List<PerformanceReview> getReviewedByManager(String managerId) throws SQLException;
+    
+    // Delete Operation
+    boolean deletePerformanceReview(int reviewId) throws SQLException;
+}


### PR DESCRIPTION
This PR introduces the **PerformanceDAO interface**, which defines all database operations related to **employee performance reviews** in the RevWorkForce system.

- fixes: #41 

**Changes Included:**

- Added methods for **leave applications**: apply, update, cancel.
- Added **manager operations**: approve, reject leave.
- Added **read operations**: fetch leaves by employee, manager, pending, etc.
- Added **leave balance operations**: get, update, assign leave balances.
- Added **leave type operations**: fetch leave types by ID or all types.
- Added **holiday operations**: get holidays by year, add new holidays.
- Added **utility methods**: check available leaves, overlapping leaves.

* fixes: #42 

**Changes Included:**

* Added methods for **creating, updating, and submitting performance reviews**.
* Added method for **adding manager feedback** with rating.
* Added methods for **retrieving reviews** by employee, year, and manager.
* Added **delete operation** to remove reviews if necessary.


These allows a clear contract for all leave-related database interactions and will be implemented in `LeaveDAOImpl` using JDBC. It ensures that leave management operations are centralized, maintainable, and easy to extend. and the **service layer** to perform performance review operations without dealing directly with SQL queries, keeping the application **modular and maintainable**.
